### PR TITLE
Support non-TLS requests to garage systems

### DIFF
--- a/db/migrate/20170825112043_add_ssl_flag_to_ica_garage_system.rb
+++ b/db/migrate/20170825112043_add_ssl_flag_to_ica_garage_system.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Some/most systems go through IPSec tunnels and don't use SSL on the HTTP level
+class AddSslFlagToICAGarageSystem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ica_garage_systems, :use_ssl, :boolean, default: false, null: false
+  end
+end

--- a/lib/ica/requests/base_request.rb
+++ b/lib/ica/requests/base_request.rb
@@ -11,8 +11,13 @@ module ICA
 
     private
 
+    def protocol
+      return 'https' if @garage_system.use_ssl?
+      'http'
+    end
+
     def request(method, path, body)
-      full_url = "https://#{@garage_system.hostname}/#{path}"
+      full_url = "#{protocol}://#{@garage_system.hostname}/#{path}"
       @response = http.request(method, full_url, body: body)
     end
 

--- a/spec/lib/ica/requests/create_accounts_spec.rb
+++ b/spec/lib/ica/requests/create_accounts_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ICA::Requests::CreateAccounts do
   let(:garage_system) { create(:garage_system) }
   let!(:customer_account_mapping1) { create(:customer_account_mapping, garage_system: garage_system) }
   let!(:customer_account_mapping2) { create(:customer_account_mapping, garage_system: garage_system) }
-  let(:expected_url) { "https://#{garage_system.hostname}/api/v1/accounts" }
+  let(:expected_url) { "http://#{garage_system.hostname}/api/v1/accounts" }
 
   shared_examples 'valid account request' do
     it 'uses chunked transfer encoding' do

--- a/spec/models/ica/garage_system_spec.rb
+++ b/spec/models/ica/garage_system_spec.rb
@@ -10,6 +10,8 @@ module ICA
     it { is_expected.to validate_uniqueness_of(:client_id) }
     it { is_expected.to have_attribute(:last_account_sync_at) }
 
+    it { is_expected.to respond_to(:use_ssl?) }
+
     describe '#auth_key' do
       it { is_expected.to validate_presence_of(:auth_key) }
       it { is_expected.to_not allow_value('g' * 64).for(:auth_key) }


### PR DESCRIPTION
Because some/most systems go through IPSec tunnels, they don't have SSL set up.