### PR TITLE
Support path prefixes for remote URLs

### DIFF
--- a/app/models/ica/garage_system.rb
+++ b/app/models/ica/garage_system.rb
@@ -20,6 +20,8 @@ module ICA
 
     enum variant: { easy_to_park: 'easy_to_park', ica: 'ica' }
 
+    validates :path_prefix, format: { with: %r{\A/[\w/]+[^/]\Z} }, if: :path_prefix
+
     include PersistedWorkflow
     workflow do
       state :prepared do

--- a/db/migrate/20170830134633_add_path_prefix_to_ica_garage_systems.rb
+++ b/db/migrate/20170830134633_add_path_prefix_to_ica_garage_systems.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Just got word that the API doesn't begin with /ica after all...
+class AddPathPrefixToICAGarageSystems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ica_garage_systems, :path_prefix, :string
+  end
+end

--- a/lib/ica/requests/base_request.rb
+++ b/lib/ica/requests/base_request.rb
@@ -17,8 +17,9 @@ module ICA
     end
 
     def request(method, path, body)
-      full_url = "#{protocol}://#{@garage_system.hostname}/#{path}"
-      @response = http.request(method, full_url, body: body)
+      base_url = "#{protocol}://#{@garage_system.hostname}"
+      base_url += @garage_system.path_prefix if @garage_system.path_prefix.present?
+      @response = http.request(method, "#{base_url}/api#{path}", body: body)
     end
 
     def response_ok?

--- a/lib/ica/requests/create_accounts.rb
+++ b/lib/ica/requests/create_accounts.rb
@@ -9,7 +9,7 @@ module ICA
     # Can be used to send updates or even re-upload everything
     # In any case, the caller is responsible for starting a database transaction
     class CreateAccounts < BaseRequest
-      PATH = 'api/v1/accounts'
+      PATH = '/v1/accounts'
 
       def initialize(garage_system, account_mappings)
         super(garage_system)

--- a/lib/ica/requests/delete_accounts.rb
+++ b/lib/ica/requests/delete_accounts.rb
@@ -5,7 +5,7 @@ require_relative 'base_request'
 module ICA
   # Deletes an account from the remote system
   class DeleteAccounts < BaseRequest
-    PATH = 'api/v1/accounts'
+    PATH = '/v1/accounts'
 
     def initialize(garage_system, customer_account_mappings)
       super(garage_system)

--- a/spec/models/ica/garage_system_spec.rb
+++ b/spec/models/ica/garage_system_spec.rb
@@ -40,6 +40,20 @@ module ICA
       end
     end
 
+    describe '#path_prefix' do
+      it 'must start with a slash' do
+        subject.path_prefix = 'foobar'
+        expect(subject).to_not be_valid
+        subject.path_prefix = '/foo/bar'
+        expect(subject).to be_valid
+      end
+
+      it 'must not end with a slash' do
+        subject.path_prefix = '/foobar/'
+        expect(subject).to_not be_valid
+      end
+    end
+
     describe 'workflow' do
       it 'is "prepared" by default' do
         expect(described_class.new).to be_prepared


### PR DESCRIPTION
Just received an email that the remote URL is `/EasyToPark/IcaInterfaceServer/ica` instead of `/ica` as in the documentation.