### PR TITLE
Also add ClientId and AuthKey to requests

### DIFF
--- a/lib/ica/requests/base_request.rb
+++ b/lib/ica/requests/base_request.rb
@@ -29,6 +29,8 @@ module ICA
     def auth_headers
       time, signature = authentication.time_and_signature
       {
+        'ClientId' => @garage_system.client_id,
+        'AuthKey' => @garage_system.auth_key,
         'LocalTime' => time,
         'Signature' => signature
       }

--- a/spec/lib/ica/requests/create_accounts_spec.rb
+++ b/spec/lib/ica/requests/create_accounts_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe ICA::Requests::CreateAccounts do
     it 'contains a signature' do
       Timecop.freeze do
         stub_request(expected_http_verb, expected_url).with do |request|
+          expect(request.headers['Clientid']).to eq(garage_system.client_id)
+          expect(request.headers['Authkey']).to eq(garage_system.auth_key)
           expect(request.headers['Localtime']).to eq(Time.now.iso8601)
           expect(request.headers['Signature']).to match(/\A\w{64}\Z/)
         end.to_return(status: 204)


### PR DESCRIPTION
These were exchanged before but we'll include them now in each request.