### PR TITLE
Explicitly set per-operation timeouts

### DIFF
--- a/lib/ica/requests/base_request.rb
+++ b/lib/ica/requests/base_request.rb
@@ -43,7 +43,8 @@ module ICA
              else
                HTTP
              end
-      base.headers(HTTP::Headers::CONTENT_TYPE => 'application/json',
+      base.timeout(write: 30, connect: 5, read: 60)
+          .headers(HTTP::Headers::CONTENT_TYPE => 'application/json',
                    HTTP::Headers::ACCEPT => 'application/json')
     end
 

--- a/spec/lib/ica/requests/base_request_spec.rb
+++ b/spec/lib/ica/requests/base_request_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'ica/requests/base_request'
+
+RSpec.describe ICA::BaseRequest do
+  let(:garage_system) { build(:garage_system) }
+  subject { described_class.new(garage_system) }
+
+  describe '#http' do
+    let(:http) { subject.send(:http) }
+
+    it 'sets per-operation timeouts' do
+      # unfortunately there's no public API to interrogate it about the timeouts
+      timeout_class, configuration = http.instance_eval do
+        [@default_options.timeout_class,
+         @default_options.timeout_options]
+      end
+      expect(timeout_class).to eq(HTTP::Timeout::PerOperation)
+      expect(configuration).to eq(read_timeout: 60,
+                                  write_timeout: 30,
+                                  connect_timeout: 5)
+    end
+  end
+end


### PR DESCRIPTION
I just ran into a `Errno::EPIPE: Broken pipe` exception when trying to `PATCH` an account. Hopefully introducing some timeouts resolves this.