### PR TITLE
Adapt separation of EASY TO PARK and evopark

### DIFF
--- a/app/services/ica/garage_system_service.rb
+++ b/app/services/ica/garage_system_service.rb
@@ -41,14 +41,18 @@ module ICA
 
     private
 
-    # Easy-To-Park systems contain all users whereas non-ETP-systems don't include ETP users
+    # Easy-To-Park systems receive easy-to-park users whereas non-ETP-systems only receive non-ETP users
+    # That means that ECE systems will need to be set up twice: once for ETP and once for evopark
+    # This is due to the way that ICA works internally to map the users to the corresponding vendor
     def all_users
-      return User.all if @garage_system.easy_to_park?
+      return User.where(brand: 'easy_to_park') if @garage_system.easy_to_park?
       User.where.not(brand: 'easy_to_park')
     end
 
     def allowed_tags
+      # unfortunately there might be some cards with UID nil, we need to exclude those or it will break things
       rfid_tags_restricted_by_test_groups.excluding(blocked_rfid_tags)
+                                         .where.not(uid: nil)
     end
 
     # TODO: in order to get this as performant and straight-forward as possible, it does not take contract parking into

--- a/lib/ica/collection_streamer.rb
+++ b/lib/ica/collection_streamer.rb
@@ -15,6 +15,7 @@ module ICA
       yield "[\n"
       first = true
       # find_each uses batches to avoid having too many queries
+      # note that this prevents limit() queries
       @mappings.find_each do |object|
         buffer = if first
                    first = false

--- a/lib/ica/requests/create_accounts.rb
+++ b/lib/ica/requests/create_accounts.rb
@@ -13,7 +13,7 @@ module ICA
 
       def initialize(garage_system, account_mappings)
         super(garage_system)
-        @account_mappings = account_mappings
+        @account_mappings = account_mappings.joins(:card_account_mappings)
       end
 
       def execute

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -36,6 +36,8 @@ Rails.application.configure do
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
+  # Raise an error if one uses `#find_each` on a relation that already has limit or order specified
+  config.active_record.error_on_ignored_order_or_limit = true
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -42,4 +42,6 @@ Rails.application.configure do
 
   # pg_dump not available on CI
   config.active_record.dump_schema_after_migration = false
+  # Raise an error if one uses `#find_each` on a relation that already has limit or order specified
+  config.active_record.error_on_ignored_order_or_limit = true
 end

--- a/spec/dummy/db/migrate/20170808080000_create_users_and_rfid_tags.rb
+++ b/spec/dummy/db/migrate/20170808080000_create_users_and_rfid_tags.rb
@@ -31,7 +31,7 @@ class CreateUsersAndRfidTags < ActiveRecord::Migration[5.0]
     create_table :rfid_tags do |t|
       t.integer :user_id, foreign_key: { references: :users }
       t.string :tag_number, null: false, index: true
-      t.string :uid, null: false, index: true
+      t.string :uid, index: true # theoretically not null, unfortunately missing in some envs
       t.string :workflow_state, null: false
       t.timestamps
     end

--- a/spec/factories/garage_systems.rb
+++ b/spec/factories/garage_systems.rb
@@ -9,6 +9,10 @@ FactoryGirl.define do
     hostname 'evopark-test.ica.de'
     variant 'ica'
 
+    trait :ica do
+      # default
+    end
+
     trait :easy_to_park do
       variant { 'easy_to_park' }
     end

--- a/spec/factories/host_models.rb
+++ b/spec/factories/host_models.rb
@@ -25,6 +25,10 @@ FactoryGirl.define do
       end
     end
 
+    trait :evopark do
+      # it's the default
+    end
+
     trait :easy_to_park do
       brand 'easy_to_park'
     end


### PR DESCRIPTION
After receiving access to the ICA test system, it became apparent that we'll need to access their system separately for EASY TO PARK and evopark.

In order to work around possible defective data (RFID tags without UID) I also added an explicit `where.not(uid: nil)` statement and ensured that only accounts with cards will ever be pushed, even if something became corrupted there.