### PR TITLE
Diversify HTTP status codes for transactions API

### DIFF
--- a/app/api/ica/api_v1.rb
+++ b/app/api/ica/api_v1.rb
@@ -27,7 +27,7 @@ module ICA
       end
 
       def call_facade(method_name, args)
-        ICA.garage_system_facade.new.public_send(method_name, { vendor: :ica }.merge(args))
+        ICA.garage_system_facade.new.public_send(method_name, { vendor: :ica }.merge(args)).deep_stringify_keys
       end
     end
 

--- a/spec/requests/api/v1/cards_spec.rb
+++ b/spec/requests/api/v1/cards_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ICA::Endpoints::V1::Cards do
         expect_any_instance_of(ICA.garage_system_facade).to receive(:block_rfid_tag).with(
           hash_including(rfid_tag: { id: card_account_mapping.rfid_tag_id },
                          garage_ids: garage_ids)
-        )
+        ).and_return(success: true)
         api_request(garage_system, :post, "/v1/lock/cards/#{card_account_mapping.card_key}")
         expect(last_response.status).to eq(204)
       end
@@ -68,7 +68,7 @@ RSpec.describe ICA::Endpoints::V1::Cards do
         expect_any_instance_of(ICA.garage_system_facade).to receive(:unblock_rfid_tag).with(
           hash_including(rfid_tag: { id: card_account_mapping.rfid_tag_id },
                          garage_ids: garage_ids)
-        )
+        ).and_return(success: true)
         api_request(garage_system, :delete, "/v1/lock/cards/#{card_account_mapping.card_key}")
         expect(last_response.status).to eq(204)
       end

--- a/spec/requests/api/v1/command_spec.rb
+++ b/spec/requests/api/v1/command_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ICA::Endpoints::V1::Command do
         create(:carpark, garage_system: garage_system, parking_garage: build(:parking_garage))
       end
       expected_facade_args = hash_including(vendor: :ica, garage_ids: carparks.map(&:parking_garage_id))
-      expect_any_instance_of(facade_class).to receive(:ping).with(expected_facade_args)
+      expect_any_instance_of(facade_class).to receive(:ping).with(expected_facade_args).and_return(success: true)
       api_request(garage_system, :get, '/v1/command')
     end
   end


### PR DESCRIPTION
When we cannot find a media ID, we'll return 422 and when an unknown parking transaction is accessed, it's 404 (as the URL contains the id).

I also removed validation on `InfoId` as I just heard from ICA that those can theoretically change and vary on a per-system basis.