### PR TITLE
Fix updating CardAccountMapping#uploaded_at

### DIFF
--- a/app/models/concerns/ica/upload_status_scopes.rb
+++ b/app/models/concerns/ica/upload_status_scopes.rb
@@ -8,6 +8,9 @@ module ICA
     included do
       scope :uploaded, -> { where.not(uploaded_at: nil) }
       scope :not_uploaded, -> { where(uploaded_at: nil) }
+
+      scope :uploaded_before, -> (timestamp) { where("#{table_name}.uploaded_at IS NOT NULL AND "\
+                                                     "#{table_name}.uploaded_at < ?", timestamp) }
     end
 
     def uploaded?

--- a/app/services/ica/customer_account_service.rb
+++ b/app/services/ica/customer_account_service.rb
@@ -11,7 +11,7 @@ module ICA
 
     def outdated_accounts
       @garage_system.customer_account_mappings.joins(:user)
-                    .where('uploaded_at IS NOT NULL AND uploaded_at < :last_sync', last_sync: last_sync)
+                    .uploaded_before(last_sync)
                     .merge(updated_users_since_last_sync)
     end
 

--- a/lib/ica/requests/create_accounts.rb
+++ b/lib/ica/requests/create_accounts.rb
@@ -35,9 +35,10 @@ module ICA
       private
 
       def update_upload_timestamps(uploaded_at)
-        @account_mappings.update_all(uploaded_at: uploaded_at)
+        # run the second query first to avoid race conditions with merging a scope based on `uploaded_at`
         CardAccountMapping.joins(:customer_account_mapping).merge(@account_mappings)
                           .update_all(uploaded_at: uploaded_at)
+        @account_mappings.update_all(uploaded_at: uploaded_at)
       end
 
       # when uploading a list of all accounts, use PUT, otherwise POST

--- a/spec/lib/ica/requests/create_accounts_spec.rb
+++ b/spec/lib/ica/requests/create_accounts_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ICA::Requests::CreateAccounts do
     # regression test to avoid duplicates for users w/ multiple cards
     let!(:card_account_mapping3) { create(:card_account_mapping, customer_account_mapping: customer_account_mapping1) }
 
-    subject { described_class.new(garage_system, garage_system.customer_account_mappings) }
+    subject { described_class.new(garage_system, garage_system.customer_account_mappings.not_uploaded) }
 
     it_behaves_like 'valid account request'
   end


### PR DESCRIPTION
Since the `ActiveRecord::Relation#merge` will create a query based on the SQL constraints of the merged-in relation, the timestamp update would fail if it was based on `uploaded_at` (i.e. the `not_uploaded`) scope.