### PR TITLE
Properly deal with duplicate card numbers

### DIFF
--- a/app/api/ica/endpoints/v1/transactions.rb
+++ b/app/api/ica/endpoints/v1/transactions.rb
@@ -91,13 +91,12 @@ module ICA::Endpoints::V1
           end
         end
 
-        # Theoretically the API supports using different media for entry or exit
-        # To keep things simple on our end, we just find the best-matching media:
-        # That should be the one from the top-level media key which contains the card number
-        # (it's specified that it's always card type 255 there)
+        # To avoid problems with duplicate card numbers, we need to look up the concrete RFID tag belonging to the
+        # media key specified in the request.
         def rfid_tag_information
+          rfid_tag_id = garage_system.card_account_mappings.find_by(card_key: params[:Media][:MediaKey]).rfid_tag_id
           {
-            rfid_tag: { tag_number: params[:Media][:MediaId] }
+            rfid_tag: { id: rfid_tag_id }
           }
         end
 

--- a/spec/requests/api/v1/transactions_spec.rb
+++ b/spec/requests/api/v1/transactions_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe ICA::Endpoints::V1::Transactions do
         AccountKey: customer_account_mapping.account_key,
         Media: {
           MediaType: 255,
-          MediaId: rfid_tag.tag_number
+          MediaId: rfid_tag.tag_number,
+          MediaKey: card_account_mapping.card_key
         },
         DriveIn: {
           DateTime: entered_at.iso8601,
@@ -58,7 +59,7 @@ RSpec.describe ICA::Endpoints::V1::Transactions do
           device_id: device_id,
           started_at: entered_at.change(usec: 0)
         },
-        rfid_tag: { tag_number: rfid_tag.tag_number },
+        rfid_tag: { id: rfid_tag.id },
         garage: { id: carpark.parking_garage_id }
       }
     end
@@ -154,7 +155,8 @@ RSpec.describe ICA::Endpoints::V1::Transactions do
         AccountKey: customer_account_mapping.account_key,
         Media: {
           MediaType: 255,
-          MediaId: rfid_tag.tag_number
+          MediaId: rfid_tag.tag_number,
+          MediaKey: card_account_mapping.card_key
         },
         Status: 1,
         DriveOut: {
@@ -177,7 +179,7 @@ RSpec.describe ICA::Endpoints::V1::Transactions do
           device_id: device_id,
           finished_at: exited_at.change(usec: 0)
         },
-        rfid_tag: { tag_number: rfid_tag.tag_number },
+        rfid_tag: { id: rfid_tag.id },
         garage: { id: carpark.parking_garage_id },
         payment: {
           amount: 12.34,


### PR DESCRIPTION
Since card numbers are not guaranteed to be unique anymore, we can't just pass them downstream to the facade but need to do our own lookup based on the cardkey/mediakey. Luckily, this has become clearer in version 3.2 of the API and is specified as being supplied for each request.