### PR TITLE
Change card account mappings relation autosave

### DIFF
--- a/app/models/ica/customer_account_mapping.rb
+++ b/app/models/ica/customer_account_mapping.rb
@@ -13,7 +13,9 @@ module ICA
     belongs_to :customer
     belongs_to :garage_system, class_name: 'ICA::GarageSystem'
 
-    has_many :card_account_mappings, class_name: 'ICA::CardAccountMapping', dependent: :destroy
+    has_many :card_account_mappings, class_name: 'ICA::CardAccountMapping',
+                                     dependent: :destroy,
+                                     autosave: true
     has_many :rfid_tags, through: :card_account_mappings
 
     before_validation :generate_account_key, on: :create

--- a/lib/ica/version.rb
+++ b/lib/ica/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ICA
-  VERSION = '1.1.5'
+  VERSION = '1.1.6'
 end


### PR DESCRIPTION
The relation card account mappings should be autosave
by default.