### PR TITLE
Add ICA message dumps

### DIFF
--- a/app/models/ica/message.rb
+++ b/app/models/ica/message.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ICA
+  # Dump incoming messages
+  class Message < ApplicationRecord
+    belongs_to :rfid_tag
+    belongs_to :parking_transaction
+    belongs_to :parking_garage
+  end
+end

--- a/app/services/ica/message_service.rb
+++ b/app/services/ica/message_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ICA
+  # Service for customer account mappings
+  class MessageService
+    attr_reader :message, :headers
+
+    def initialize(message, headers:)
+      @message = message
+      @headers = headers
+    end
+
+    def build_ica_message(facade_response = {})
+      return build_message(remark: facade_response) unless facade_response['success']
+
+      build_message parking_transaction: parking_transaction
+    end
+
+    private
+
+    def build_message(attributes)
+      ::ICA::Message.new attributes.merge(rfid_tag: rfid_tag,
+                                          parking_garage: parking_garage,
+                                          message: message,
+                                          headers: headers)
+    end
+
+    def uuid
+      message.dig 'DriveIn', 'Media', 'MediaId'
+    end
+
+    def rfid_tag
+      ::RfidTag.with_deleted.find_by_uuid uuid
+    end
+
+    def parking_transaction
+      return if message['transaction_id'].blank?
+
+      ::ParkingTransaction.find_by_external_key message['transaction_id']
+    end
+
+    def carpark
+      @carpark ||= ::ICA::Carpark.find_by_carpark_id message[:CarParkId]
+    end
+
+    delegate :parking_garage, to: :carpark, allow_nil: true
+  end
+end

--- a/lib/ica/version.rb
+++ b/lib/ica/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ICA
-  VERSION = '1.1.24'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
ICA message dump are meant to dump incoming messages
from ICA.
The evopark API is expected to always process the ICA
messages as long as they are syntactically correct.
No matter what.
So the API is expected to always return a 204.