### PR TITLE
Refactor ICA transactions API

### DIFF
--- a/lib/ica/version.rb
+++ b/lib/ica/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ICA
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
We always should take ICA events off as long as they
are syntactically correct.